### PR TITLE
Rename the crate as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,19 +389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thingy"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "directories-next",
- "rand",
- "serde",
- "tinybit",
- "toml",
-]
-
-[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,3 +452,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wonky"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "directories-next",
+ "rand",
+ "serde",
+ "tinybit",
+ "toml",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "thingy"
+name = "wonky"
 version = "0.1.0"
 authors = ["gorg <gorgmakesthings@gmail.com>"]
 edition = "2018"


### PR DESCRIPTION
The repository was renamed but the crate wasn't yet so the resulting binary is still named thingy instead of wonky.﻿